### PR TITLE
Unify filename generation routines between Streamer and Logger

### DIFF
--- a/pybela/Logger.py
+++ b/pybela/Logger.py
@@ -58,8 +58,8 @@ class Logger(Watcher):
                     logging_dir, os.path.basename(remote_paths[var]))
 
                 # if file already exists, throw a warning and add number at the end of the filename
-                local_paths[var] = self._generate_local_filename(
-                    local_path)
+                local_paths[var] = self._generate_unique_filename(
+                    os.path.basename(local_path), os.path.dirname(local_path))
 
                 copying_task = self.__copy_file_in_chunks(
                     remote_paths[var], local_paths[var])
@@ -121,8 +121,8 @@ class Logger(Watcher):
                         logging_dir, os.path.basename(remote_paths[var]))
 
                     # if file already exists, throw a warning and add number at the end of the filename
-                    local_paths[var] = self._generate_local_filename(
-                        local_path)
+                    local_paths[var] = self._generate_unique_filename(
+                        os.path.basename(local_path), os.path.dirname(local_path))
 
                     copying_task = self.__copy_file_in_chunks(
                         remote_paths[var], local_paths[var])

--- a/pybela/Streamer.py
+++ b/pybela/Streamer.py
@@ -166,6 +166,9 @@ class Streamer(Watcher):
         self._saving_filename = self._generate_unique_filename(
             saving_filename, saving_dir, use_streamer_pattern=True) if saving_enabled else None
 
+        if self._saving_enabled:
+            _print_info(f"Streamed data will be saved to {self._saving_filename}")
+
         async def async_callback_workers():
 
             if on_block_callback and on_buffer_callback:
@@ -792,7 +795,6 @@ class Streamer(Watcher):
 
         # finally:
         #     await self._async_remove_item_from_list(self._active_saving_tasks, asyncio.current_task())
-
 
     async def _async_remove_item_from_list(self, _list, task):
         """ Removes a task from a list of tasks asynchronously. This function is called by _save_data_to_file() when a task is finished.

--- a/pybela/Streamer.py
+++ b/pybela/Streamer.py
@@ -51,7 +51,7 @@ class Streamer(Watcher):
 
         # -- save --
         self._saving_enabled = False
-        self._saving_filename = None
+        self._saving_base_filename = None
         self._saving_task = None
         self._active_saving_tasks = []
         self._saving_file_locks = {}
@@ -163,11 +163,11 @@ class Streamer(Watcher):
             os.makedirs(saving_dir)
 
         self._saving_enabled = True if saving_enabled else False
-        self._saving_filename = self._generate_unique_filename(
+        self._saving_base_filename = self._generate_unique_filename(
             saving_filename, saving_dir, use_streamer_pattern=True) if saving_enabled else None
 
         if self._saving_enabled:
-            _print_info(f"Streamed data will be saved to {self._saving_filename}")
+            _print_info(f"Streamed data will be saved to <var_name>_{self._saving_base_filename}")
 
         async def async_callback_workers():
 
@@ -252,7 +252,7 @@ class Streamer(Watcher):
 
         if self._saving_enabled:
             self._saving_enabled = False
-            self._saving_filename = None
+            self._saving_base_filename = None
             # await all active saving tasks
             await asyncio.gather(*self._active_saving_tasks, return_exceptions=True)
             self._active_saving_tasks.clear()
@@ -513,7 +513,7 @@ class Streamer(Watcher):
                 # save data to file if saving is enabled
                 if _saving_enabled:
                     _saving_var_filename = os.path.join(os.path.dirname(
-                        self._saving_filename), f"{var_name}_{os.path.basename(self._saving_filename)}")
+                        self._saving_base_filename), f"{var_name}_{os.path.basename(self._saving_base_filename)}")
                     # save the data asynchronously
                     saving_task = self.loop.create_task(
                         self._save_data_to_file(_saving_var_filename, parsed_buffer))

--- a/pybela/Streamer.py
+++ b/pybela/Streamer.py
@@ -163,8 +163,8 @@ class Streamer(Watcher):
             os.makedirs(saving_dir)
 
         self._saving_enabled = True if saving_enabled else False
-        self._saving_filename = self._generate_filename(
-            saving_filename, saving_dir) if saving_enabled else None
+        self._saving_filename = self._generate_unique_filename(
+            saving_filename, saving_dir, use_streamer_pattern=True) if saving_enabled else None
 
         async def async_callback_workers():
 
@@ -793,28 +793,6 @@ class Streamer(Watcher):
         # finally:
         #     await self._async_remove_item_from_list(self._active_saving_tasks, asyncio.current_task())
 
-    def _generate_filename(self, saving_filename, saving_dir="./"):
-        """ Generates a filename for saving data by adding the variable name and a number at the end in case the filename already exists to avoid overwriting saved data. Pattern: varname_filename__idx.ext.  This function is called by start_streaming() and stream_n_values() when saving is enabled.
-
-        Args:
-            saving_filename (str): Root filename
-
-        Returns:
-            str: Generated filename
-        """
-
-        filename_wo_ext, filename_ext = os.path.splitext(saving_filename)
-        # files that follow naming convention, returns list of varname_filename (no __idx.ext)
-        matching_files = [os.path.splitext(file)[0].split(
-            "__")[0] for file in glob.glob(os.path.join(saving_dir, f"*{filename_wo_ext}*{filename_ext}"))]
-
-        if not matching_files:
-            return os.path.join(saving_dir, saving_filename)
-
-        # counts files with the same varname_filename
-        idx = max([matching_files.count(item) for item in set(matching_files)])
-
-        return os.path.join(saving_dir, f"{filename_wo_ext}__{idx}{filename_ext}")
 
     async def _async_remove_item_from_list(self, _list, task):
         """ Removes a task from a list of tasks asynchronously. This function is called by _save_data_to_file() when a task is finished.

--- a/pybela/Watcher.py
+++ b/pybela/Watcher.py
@@ -634,50 +634,50 @@ class Watcher:
 
     def _generate_unique_filename(self, filename, directory="./", use_streamer_pattern=False):
         """Generate unique filename by avoiding collisions with existing files.
-        
+
         This unified method replaces both _generate_local_filename and Streamer._generate_filename.
         It handles collision avoidance for both simple incremental naming and streamer session-based naming.
-        
+
         Args:
             filename (str): Base filename
             directory (str, optional): Directory path. Defaults to "./".
             use_streamer_pattern (bool, optional): If True, uses Streamer's session-based pattern that accounts
                                                    for variable-prefixed files. Defaults to False.
-            
+
         Returns:
             str: Full path to unique filename
-            
+
         Examples:
             _generate_unique_filename("data.txt", "./") -> "./data.txt" or "./data_1.txt"
             _generate_unique_filename("stream.txt", "./", True) -> "./stream.txt" or "./stream__1.txt"
         """
         import os
         import glob
-        
+
         if not os.path.exists(directory):
             os.makedirs(directory)
-            
+
         filename_wo_ext, filename_ext = os.path.splitext(filename)
         full_base_path = os.path.join(directory, filename)
-        
+
         if use_streamer_pattern:
             # Streamer pattern: Handle session-based conflicts, accounting for variable-prefixed files
             # Look for files that match the pattern *filename.ext (including variable-prefixed versions)
-            matching_files = [os.path.splitext(file)[0].split("__")[0] for file in 
-                             glob.glob(os.path.join(directory, f"*{filename_wo_ext}*{filename_ext}"))]
-            
+            matching_files = [os.path.splitext(file)[0].split("__")[0] for file in
+                              glob.glob(os.path.join(directory, f"*{filename_wo_ext}*{filename_ext}"))]
+
             if not matching_files:
                 return full_base_path
-            
+
             # Count files with the same base pattern to determine next session index
             idx = max([matching_files.count(item) for item in set(matching_files)])
             return os.path.join(directory, f"{filename_wo_ext}__{idx}{filename_ext}")
-            
+
         else:
             # Simple pattern: Direct file-by-file collision avoidance
             if not os.path.exists(full_base_path):
                 return full_base_path
-                
+
             counter = 1
             while True:
                 new_path = os.path.join(directory, f"{filename_wo_ext}_{counter}{filename_ext}")
@@ -811,7 +811,7 @@ class Watcher:
             if verbose:
                 _print_ok(
                     f"\rTransferring {remote_path}-->{_local_path}... Done.")
-            return local_path
+            return _local_path
         except asyncio.exceptions.TimeoutError:
             _print_error(
                 f"Error while transferring file: TimeoutError.")

--- a/pybela/Watcher.py
+++ b/pybela/Watcher.py
@@ -632,6 +632,61 @@ class Watcher:
 
         return new_local_path
 
+    def _generate_unique_filename(self, filename, directory="./", use_streamer_pattern=False):
+        """Generate unique filename by avoiding collisions with existing files.
+        
+        This unified method replaces both _generate_local_filename and Streamer._generate_filename.
+        It handles collision avoidance for both simple incremental naming and streamer session-based naming.
+        
+        Args:
+            filename (str): Base filename
+            directory (str, optional): Directory path. Defaults to "./".
+            use_streamer_pattern (bool, optional): If True, uses Streamer's session-based pattern that accounts
+                                                   for variable-prefixed files. Defaults to False.
+            
+        Returns:
+            str: Full path to unique filename
+            
+        Examples:
+            _generate_unique_filename("data.txt", "./") -> "./data.txt" or "./data_1.txt"
+            _generate_unique_filename("stream.txt", "./", True) -> "./stream.txt" or "./stream__1.txt"
+        """
+        import os
+        import glob
+        
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+            
+        filename_wo_ext, filename_ext = os.path.splitext(filename)
+        full_base_path = os.path.join(directory, filename)
+        
+        if use_streamer_pattern:
+            # Streamer pattern: Handle session-based conflicts, accounting for variable-prefixed files
+            # Look for files that match the pattern *filename.ext (including variable-prefixed versions)
+            matching_files = [os.path.splitext(file)[0].split("__")[0] for file in 
+                             glob.glob(os.path.join(directory, f"*{filename_wo_ext}*{filename_ext}"))]
+            
+            if not matching_files:
+                return full_base_path
+            
+            # Count files with the same base pattern to determine next session index
+            idx = max([matching_files.count(item) for item in set(matching_files)])
+            return os.path.join(directory, f"{filename_wo_ext}__{idx}{filename_ext}")
+            
+        else:
+            # Simple pattern: Direct file-by-file collision avoidance
+            if not os.path.exists(full_base_path):
+                return full_base_path
+                
+            counter = 1
+            while True:
+                new_path = os.path.join(directory, f"{filename_wo_ext}_{counter}{filename_ext}")
+                if not os.path.exists(new_path):
+                    from .utils import _print_warning
+                    _print_warning(f"{full_base_path} already exists. Renaming file to {new_path}")
+                    return new_path
+                counter += 1
+
     def get_prop_of_var(self, var_name, prop):
         """Get property of variable. Properties: name, type, timestamp_mode, log_filename, data_length
 
@@ -743,7 +798,8 @@ class Watcher:
         try:
             _local_path = None
             if os.path.exists(local_path):
-                _local_path = self._generate_local_filename(local_path)
+                _local_path = self._generate_unique_filename(
+                    os.path.basename(local_path), os.path.dirname(local_path))
             else:
                 _local_path = local_path
             transferred_event = asyncio.Event()

--- a/pybela/Watcher.py
+++ b/pybela/Watcher.py
@@ -4,6 +4,7 @@ import json
 import errno
 import struct
 import os
+import glob
 import nest_asyncio
 import paramiko
 from .utils import _print_error, _print_warning, _print_ok
@@ -651,9 +652,6 @@ class Watcher:
             _generate_unique_filename("data.txt", "./") -> "./data.txt" or "./data_1.txt"
             _generate_unique_filename("stream.txt", "./", True) -> "./stream.txt" or "./stream__1.txt"
         """
-        import os
-        import glob
-
         if not os.path.exists(directory):
             os.makedirs(directory)
 

--- a/readme.md
+++ b/readme.md
@@ -231,7 +231,6 @@ sh dev/test-docs.sh
 - [ ] **Issue:** Monitor and streamer/controller can't be used simultaneously –  This is due to both monitor and streamer both using the same websocket connection and message format. This could be fixed by having a different message format for the monitor and the streamer (e.g., adding a header to the message)
 - [ ] **Issue:** The plotting routine does not work when variables are updated at different rates.
 - [ ] **Issue**: The plotting routine does not work for the monitor (it only works for the streamer)
-- [ ] **Code refactor:** There are two routines for generating filenames (for Streamer and for Logger). This should be unified.
 - [ ] **Possible feature:** Flexible backend buffer size for streaming: if the assign rate of variables is too slow, the buffers might not be filled and hence not sent (since the data flushed is not collected in the frontend), and there will be long delays between the variable assign and the data being sent to the frontend.
 - [ ] **Issue:** Flushed buffers are not collected after `stop_streaming` in the frontend.
 

--- a/test/test.py
+++ b/test/test.py
@@ -7,11 +7,13 @@ from pybela import Watcher, Streamer, Logger, Monitor, Controller
 
 # all tests should be run with Bela connected and the bela-test project (in test/bela-test) running on the board
 
+ip = "192.168.7.2"
+
 
 class test_Watcher(unittest.TestCase):
 
     def setUp(self):
-        self.watcher = Watcher()
+        self.watcher = Watcher(ip=ip)
         self.watcher.connect()
 
     def tearDown(self):
@@ -33,7 +35,7 @@ class test_Watcher(unittest.TestCase):
 class test_Streamer(unittest.TestCase):
 
     def setUp(self):
-        self.streamer = Streamer()
+        self.streamer = Streamer(ip=ip)
         self.streamer.connect()
         self.streaming_vars = [
             "myvar",  # dense double
@@ -191,7 +193,7 @@ class test_Streamer(unittest.TestCase):
 class test_Logger(unittest.TestCase):
 
     def setUp(self):
-        self.logger = Logger()
+        self.logger = Logger(ip=ip)
         self.logger.connect()
 
         self.logging_vars = [
@@ -259,8 +261,8 @@ class test_Logger(unittest.TestCase):
         local_paths = {}
         for var in file_paths["remote_paths"]:
             filename = os.path.basename(file_paths["remote_paths"][var])
-            local_paths[var] = self.logger.copy_file_from_bela(remote_path=file_paths["remote_paths"][var],
-                                                               local_path=filename)
+            local_paths[var] = self.logger.copy_file_from_bela(
+                remote_path=file_paths["remote_paths"][var], local_path=os.path.join(self.logging_dir, filename))
 
         # test logged data
         self._test_logged_data(self.logger, self.logging_vars, local_paths)
@@ -307,7 +309,7 @@ class test_Monitor(unittest.TestCase):
         self.saving_filename = "test_monitor_save.txt"
         self.saving_dir = "./test"
 
-        self.monitor = Monitor()
+        self.monitor = Monitor(ip=ip)
         self.monitor.connect()
 
     def tearDown(self):
@@ -383,7 +385,7 @@ class test_Controller(unittest.TestCase):
     def setUp(self):
         self.controlled_vars = ["myvar", "myvar2", "myvar3", "myvar4"]
 
-        self.controller = Controller()
+        self.controller = Controller(ip=ip)
         self.controller.connect()
 
     def tearDown(self):
@@ -464,6 +466,7 @@ def run_tests():
         # suite.addTest(test_Streamer('test_on_block_callback'))
         runner = unittest.TextTestRunner(verbosity=2)
         runner.run(suite)
+
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
## Summary

  Consolidates duplicate filename generation methods from `Streamer` and `Logger` into a single
  `_generate_unique_filename()` method in the `Watcher` base class.

  ## Changes

  - Removes `Streamer._generate_filename()`
  - Adds unified method supporting both simple (`file_1.txt`) and streamer (`file__1.txt`) patterns
  - Updates `Streamer` and `Logger` to use new method
  - Preserves all existing functionality
